### PR TITLE
k8s overlay for ceramic/composedb load testing

### DIFF
--- a/k8s/overlays/ceramic-load-test/create-secrets.sh
+++ b/k8s/overlays/ceramic-load-test/create-secrets.sh
@@ -1,0 +1,6 @@
+kubectl create secret generic postgres-auth \
+  --namespace ceramic-load-test \
+  --from-literal=username=ceramic --from-literal=password=$(openssl rand -hex 20)
+kubectl create secret generic ceramic-admin \
+  --namespace ceramic-load-test \
+  --from-literal=private-key=$(openssl rand -hex 32)

--- a/k8s/overlays/ceramic-load-test/kustomization.yaml
+++ b/k8s/overlays/ceramic-load-test/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+namespace: ceramic-load-test
+
+bases:
+  - ../../base
+
+resources:
+  - ./manifests/runner.yaml
+  - ./manifests/runner-create.yaml
+
+images:
+  - name: 3boxben/runner
+    newName: 3boxben/composedb@sha256
+    newTag: d404fb8c8c1c49a02002365032a315d5d0e680e2b9bb3cf776d9bd39665f3c4c
+
+configMapGenerator:
+  - name: schemas
+    files:
+      - ./schemas/SmokeTestModel-main.graphql
+      - ./schemas/SmokeTestModel-relation.graphql
+  - name: scripts
+    files:
+      - ./scripts/create-doc.sh
+  - name: runner-env
+    envs:
+      - ./runner.env

--- a/k8s/overlays/ceramic-load-test/manifests/runner-create.yaml
+++ b/k8s/overlays/ceramic-load-test/manifests/runner-create.yaml
@@ -1,0 +1,45 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: runner-create
+  namespace: default
+  labels:
+    app: runner-create
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: runner-create
+  template:
+    metadata:
+      labels:
+        app: runner-create
+    spec:
+      containers:
+        - name: runner-create
+          image: 3boxben/runner
+          command: ["/scripts/create-doc.sh"]
+          resources:
+            limits:
+              cpu: "2"
+              ephemeral-storage: 1Gi
+              memory: 4Gi
+          env:
+            - name: CERAMIC_ADMIN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ceramic-admin
+                  key: private-key
+          envFrom:
+            - configMapRef:
+                name: runner-env
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+      volumes:
+        - name: scripts
+          configMap:
+            name: scripts
+            defaultMode: 0755
+

--- a/k8s/overlays/ceramic-load-test/manifests/runner.yaml
+++ b/k8s/overlays/ceramic-load-test/manifests/runner.yaml
@@ -1,0 +1,40 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: runner
+  namespace: default
+  labels:
+    app: runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: runner
+  template:
+    metadata:
+      labels:
+        app: runner
+    spec:
+      containers:
+        - name: runner
+          image: 3boxben/runner
+          command: ["/bin/sh", "-c", "sleep infinity"]
+          resources:
+            limits:
+              cpu: "2"
+              ephemeral-storage: 1Gi
+              memory: 4Gi
+          env:
+            - name: CERAMIC_ADMIN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ceramic-admin
+                  key: private-key
+          volumeMounts:
+            - name: schemas
+              mountPath: /schemas
+      volumes:
+        - name: schemas
+          configMap:
+            name: schemas

--- a/k8s/overlays/ceramic-load-test/runner.env
+++ b/k8s/overlays/ceramic-load-test/runner.env
@@ -1,0 +1,2 @@
+SLEEP_TIME=1
+MODEL_DEPLOYED_ID=kjzl6hvfrbw6c5vbepogjxrpm3kbk80dgtq5do8jj16cdiidx08k9bjs9s1aelo

--- a/k8s/overlays/ceramic-load-test/schemas/SmokeTestModel-main.graphql
+++ b/k8s/overlays/ceramic-load-test/schemas/SmokeTestModel-main.graphql
@@ -1,0 +1,3 @@
+type SmokeTestModel @createModel(accountRelation: LIST, description:"Smoke Test Model") {
+  data: Int! @int(min: 0, max: 10000)
+}

--- a/k8s/overlays/ceramic-load-test/schemas/SmokeTestModel-relation.graphql
+++ b/k8s/overlays/ceramic-load-test/schemas/SmokeTestModel-relation.graphql
@@ -1,0 +1,8 @@
+type SmokeTestModel @loadModel(id: <smoke-test-model-stream-id>) {
+    id: ID!
+}
+
+type MyModel @createModel(accountRelation: LIST, description:"Smoke Test Model") {
+  linkedDocID: StreamID! @documentReference(model: "SmokeTestModel")
+  linkedDoc: SmokeTestModel @relationDocument(property: "linkedDocID")
+}

--- a/k8s/overlays/ceramic-load-test/scripts/create-doc.sh
+++ b/k8s/overlays/ceramic-load-test/scripts/create-doc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exo pipefail
+
+while true;do
+    composedb document:create \
+    ${MODEL_DEPLOYED_ID} \
+    '{"data":1234}'\
+    --ceramic-url=http://composedb:7007 \
+    --did-private-key=$CERAMIC_ADMIN_PRIVATE_KEY
+
+    sleep ${SLEEP_TIME}
+done


### PR DESCRIPTION
Here's an overlay for the load tests.

The create script is using the SmokeTest-Main model atm and just doing creates.

`k8s/overlays/ceramic-load-test/scripts/create-doc.sh`

The model deployment and feeding the stream ID to the runner env is manual, but the runners can scale with the deployment.